### PR TITLE
Added system mode detection for dark and light themes

### DIFF
--- a/script.js
+++ b/script.js
@@ -229,9 +229,22 @@ document.addEventListener('DOMContentLoaded', function () {
 });
 
 // Dark mode toggle
+// Immediately apply the stored dark mode preference
+(function() {
+    const darkModeStatus = localStorage.getItem('darkMode');
+    
+    if (darkModeStatus === 'enabled') {
+        document.body.classList.add('dark-mode');
+    }
+})();
+
+// Toggle dark mode and save the preference
 document.getElementById('dark-mode-toggle').addEventListener('click', () => {
-    document.body.classList.toggle('dark-mode');
+    const isDarkMode = document.body.classList.toggle('dark-mode');
+    
+    localStorage.setItem('darkMode', isDarkMode ? 'enabled' : 'disabled');
 });
+
 
 // Mobile menu functionality
 const mobileMenuBtn = document.querySelector('.mobile-menu-btn');

--- a/script.js
+++ b/script.js
@@ -228,23 +228,24 @@ document.addEventListener('DOMContentLoaded', function () {
     });
 });
 
-// Dark mode toggle
-// Immediately apply the stored dark mode preference
-(function() {
+// Dark mode toggle based on preference
+function applyDarkModePreference() {
     const darkModeStatus = localStorage.getItem('darkMode');
-    
     if (darkModeStatus === 'enabled') {
         document.body.classList.add('dark-mode');
+    } else {
+        document.body.classList.remove('dark-mode');
     }
-})();
+}
+
+// Immediately apply the stored dark mode preference
+applyDarkModePreference();
 
 // Toggle dark mode and save the preference
 document.getElementById('dark-mode-toggle').addEventListener('click', () => {
     const isDarkMode = document.body.classList.toggle('dark-mode');
-    
     localStorage.setItem('darkMode', isDarkMode ? 'enabled' : 'disabled');
 });
-
 
 // Mobile menu functionality
 const mobileMenuBtn = document.querySelector('.mobile-menu-btn');


### PR DESCRIPTION
# Fixes Issue🛠️
<!-- Example: Closes #32 -->

Closes #50 

# Description👨‍💻
<!-- Please include a summary of your changes. -->

Now the website retains the mode selected (dark/light) even when the page is reload or another html file is visited. The theme preference is stored in local storage, so that whenever you open the website, it remembers your choice.  

# Type of Change📄
<!-- Please delete the options that are not relevant to you. -->

- [X] New feature (non-breaking change which adds functionality)

# Checklist✅
<!-- Please delete the options that are not relevant to you. -->

- [X] I am an Open Source contributor
- [X] I have performed a self-review of my code
- [X] My code follows the style guidelines of this project
- [X] I have commented on my code, particularly in hard-to-understand areas

# Screenshots/GIF📷
<!-- Please add screenshots or a GIF to demonstrate your changes. -->

https://github.com/user-attachments/assets/7dafda31-a9c0-4770-9552-fd3f0bb063a7
